### PR TITLE
Add analytics dashboards with supporting API endpoints

### DIFF
--- a/Hospital_Code/src/main/java/com/hospital/controlador/AnaliticaControlador.java
+++ b/Hospital_Code/src/main/java/com/hospital/controlador/AnaliticaControlador.java
@@ -1,0 +1,36 @@
+package com.hospital.controlador;
+
+import com.hospital.modelo.dto.EstadisticaDto;
+import com.hospital.modelo.dto.SerieTemporalDto;
+import com.hospital.modelo.servicio.IAnaliticaServicio;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/datos")
+public class AnaliticaControlador {
+
+    private final IAnaliticaServicio analiticaServicio;
+
+    public AnaliticaControlador(IAnaliticaServicio analiticaServicio) {
+        this.analiticaServicio = analiticaServicio;
+    }
+
+    @GetMapping("/personas-tipo")
+    public List<EstadisticaDto> personasPorTipo() {
+        return analiticaServicio.personasPorTipo();
+    }
+
+    @GetMapping("/ingresos-estado")
+    public List<EstadisticaDto> ingresosPorEstado() {
+        return analiticaServicio.ingresosPorEstado();
+    }
+
+    @GetMapping("/citas-mensuales")
+    public List<SerieTemporalDto> citasPorMes() {
+        return analiticaServicio.citasPorMes();
+    }
+}

--- a/Hospital_Code/src/main/java/com/hospital/modelo/dto/EstadisticaDto.java
+++ b/Hospital_Code/src/main/java/com/hospital/modelo/dto/EstadisticaDto.java
@@ -1,0 +1,31 @@
+package com.hospital.modelo.dto;
+
+public class EstadisticaDto {
+
+    private String etiqueta;
+    private long valor;
+
+    public EstadisticaDto(String etiqueta, long valor) {
+        this.etiqueta = etiqueta;
+        this.valor = valor;
+    }
+
+    public EstadisticaDto() {
+    }
+
+    public String getEtiqueta() {
+        return etiqueta;
+    }
+
+    public void setEtiqueta(String etiqueta) {
+        this.etiqueta = etiqueta;
+    }
+
+    public long getValor() {
+        return valor;
+    }
+
+    public void setValor(long valor) {
+        this.valor = valor;
+    }
+}

--- a/Hospital_Code/src/main/java/com/hospital/modelo/dto/SerieTemporalDto.java
+++ b/Hospital_Code/src/main/java/com/hospital/modelo/dto/SerieTemporalDto.java
@@ -1,0 +1,31 @@
+package com.hospital.modelo.dto;
+
+public class SerieTemporalDto {
+
+    private String periodo;
+    private long total;
+
+    public SerieTemporalDto(String periodo, long total) {
+        this.periodo = periodo;
+        this.total = total;
+    }
+
+    public SerieTemporalDto() {
+    }
+
+    public String getPeriodo() {
+        return periodo;
+    }
+
+    public void setPeriodo(String periodo) {
+        this.periodo = periodo;
+    }
+
+    public long getTotal() {
+        return total;
+    }
+
+    public void setTotal(long total) {
+        this.total = total;
+    }
+}

--- a/Hospital_Code/src/main/java/com/hospital/modelo/repositorio/CitaRepositorio.java
+++ b/Hospital_Code/src/main/java/com/hospital/modelo/repositorio/CitaRepositorio.java
@@ -1,17 +1,19 @@
 package com.hospital.modelo.repositorio;
 
 
-import com.hospital.modelo.dto.CitaDto;
+import com.hospital.modelo.dto.SerieTemporalDto;
 import com.hospital.modelo.entidad.Cita;
 
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import java.util.List;
 
 @Repository
 public interface CitaRepositorio extends CrudRepository<Cita,Integer> {
 
+    @Query("SELECT new com.hospital.modelo.dto.SerieTemporalDto(FUNCTION('FORMAT', c.fechaCita, 'yyyy-MM'), COUNT(c)) " +
+            "FROM Cita c GROUP BY FUNCTION('FORMAT', c.fechaCita, 'yyyy-MM') ORDER BY FUNCTION('FORMAT', c.fechaCita, 'yyyy-MM')")
+    List<SerieTemporalDto> contarCitasPorMes();
 }

--- a/Hospital_Code/src/main/java/com/hospital/modelo/repositorio/IngresosRepositorio.java
+++ b/Hospital_Code/src/main/java/com/hospital/modelo/repositorio/IngresosRepositorio.java
@@ -1,5 +1,6 @@
 package com.hospital.modelo.repositorio;
 
+import com.hospital.modelo.dto.EstadisticaDto;
 import com.hospital.modelo.dto.IngresoDto;
 import com.hospital.modelo.entidad.Ingresos;
 import org.springframework.data.jpa.repository.Query;
@@ -7,9 +8,15 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface IngresosRepositorio extends CrudRepository<Ingresos,Integer> {
 
     @Query("select new com.hospital.modelo.dto.IngresoDto(i.idIngreso,i.persona.idPersona,i.habitacion.numHabitacion, i.acompañante,i.hospitalizado) from Ingresos i where i.persona.idPersona=:id")
     IngresoDto buscarPorPaciente(@Param("id")int id);
+
+    @Query("SELECT new com.hospital.modelo.dto.EstadisticaDto(CASE WHEN i.hospitalizado = true THEN 'Hospitalizados' ELSE 'Ambulatorios' END, COUNT(i)) " +
+            "FROM Ingresos i GROUP BY i.hospitalizado")
+    List<EstadisticaDto> contarPorEstadoHospitalizacion();
 }

--- a/Hospital_Code/src/main/java/com/hospital/modelo/repositorio/PersonaRepositorio.java
+++ b/Hospital_Code/src/main/java/com/hospital/modelo/repositorio/PersonaRepositorio.java
@@ -2,6 +2,7 @@ package com.hospital.modelo.repositorio;
 
 
 
+import com.hospital.modelo.dto.EstadisticaDto;
 import com.hospital.modelo.dto.PersonaDto;
 import com.hospital.modelo.dto.ServicioDto;
 import com.hospital.modelo.entidad.Persona;
@@ -34,5 +35,9 @@ public interface PersonaRepositorio extends CrudRepository<Persona,Integer> {
 
     @Query("SELECT new com.hospital.modelo.dto.ServicioDto(s.codServicio, s.nomServicio, s.precioServicio, s.detallesServicio) FROM Persona p JOIN p.servicios s WHERE p.idPersona = :id")
     List<ServicioDto> serviciosPersona(@Param("id") int id);
+
+    @Query("SELECT new com.hospital.modelo.dto.EstadisticaDto(CASE WHEN p.tipoPersona = true THEN 'Medicos' ELSE 'Pacientes' END, COUNT(p)) " +
+            "FROM Persona p WHERE p.activo = true GROUP BY p.tipoPersona")
+    List<EstadisticaDto> contarPorTipoPersona();
 
 }

--- a/Hospital_Code/src/main/java/com/hospital/modelo/servicio/AnaliticaServicio.java
+++ b/Hospital_Code/src/main/java/com/hospital/modelo/servicio/AnaliticaServicio.java
@@ -1,0 +1,41 @@
+package com.hospital.modelo.servicio;
+
+import com.hospital.modelo.dto.EstadisticaDto;
+import com.hospital.modelo.dto.SerieTemporalDto;
+import com.hospital.modelo.repositorio.CitaRepositorio;
+import com.hospital.modelo.repositorio.IngresosRepositorio;
+import com.hospital.modelo.repositorio.PersonaRepositorio;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class AnaliticaServicio implements IAnaliticaServicio {
+
+    private final PersonaRepositorio personaRepositorio;
+    private final IngresosRepositorio ingresosRepositorio;
+    private final CitaRepositorio citaRepositorio;
+
+    public AnaliticaServicio(PersonaRepositorio personaRepositorio,
+                             IngresosRepositorio ingresosRepositorio,
+                             CitaRepositorio citaRepositorio) {
+        this.personaRepositorio = personaRepositorio;
+        this.ingresosRepositorio = ingresosRepositorio;
+        this.citaRepositorio = citaRepositorio;
+    }
+
+    @Override
+    public List<EstadisticaDto> personasPorTipo() {
+        return personaRepositorio.contarPorTipoPersona();
+    }
+
+    @Override
+    public List<EstadisticaDto> ingresosPorEstado() {
+        return ingresosRepositorio.contarPorEstadoHospitalizacion();
+    }
+
+    @Override
+    public List<SerieTemporalDto> citasPorMes() {
+        return citaRepositorio.contarCitasPorMes();
+    }
+}

--- a/Hospital_Code/src/main/java/com/hospital/modelo/servicio/IAnaliticaServicio.java
+++ b/Hospital_Code/src/main/java/com/hospital/modelo/servicio/IAnaliticaServicio.java
@@ -1,0 +1,15 @@
+package com.hospital.modelo.servicio;
+
+import com.hospital.modelo.dto.EstadisticaDto;
+import com.hospital.modelo.dto.SerieTemporalDto;
+
+import java.util.List;
+
+public interface IAnaliticaServicio {
+
+    List<EstadisticaDto> personasPorTipo();
+
+    List<EstadisticaDto> ingresosPorEstado();
+
+    List<SerieTemporalDto> citasPorMes();
+}

--- a/Hospital_Code/src/main/resources/static/Scripts/Datos/datos.js
+++ b/Hospital_Code/src/main/resources/static/Scripts/Datos/datos.js
@@ -1,0 +1,154 @@
+const API_BASE = "http://localhost:8080";
+
+const chartConfigurations = [
+    {
+        endpoint: "/datos/personas-tipo",
+        elementId: "personasTipoChart",
+        type: "doughnut",
+        labelKey: "etiqueta",
+        valueKey: "valor",
+        datasetLabel: "Personas",
+        colors: ["#00b894", "#0984e3", "#6c5ce7", "#fdcb6e"],
+        options: {
+            plugins: {
+                legend: { position: "bottom" }
+            }
+        }
+    },
+    {
+        endpoint: "/datos/ingresos-estado",
+        elementId: "ingresosEstadoChart",
+        type: "doughnut",
+        labelKey: "etiqueta",
+        valueKey: "valor",
+        datasetLabel: "Ingresos",
+        colors: ["#e17055", "#00cec9", "#fab1a0"],
+        options: {
+            plugins: {
+                legend: { position: "bottom" }
+            }
+        }
+    },
+    {
+        endpoint: "/datos/citas-mensuales",
+        elementId: "citasMensualesChart",
+        type: "line",
+        labelKey: "periodo",
+        valueKey: "total",
+        datasetLabel: "Citas",
+        colors: ["#00b894"],
+        options: {
+            scales: {
+                y: {
+                    beginAtZero: true,
+                    ticks: {
+                        precision: 0
+                    }
+                }
+            },
+            plugins: {
+                legend: { display: false }
+            }
+        }
+    }
+];
+
+const DEFAULT_COLORS = ["#00b894", "#6c5ce7", "#0984e3", "#fdcb6e", "#e17055", "#00cec9", "#b2bec3"];
+
+function resolveColors(config, dataLength) {
+    const palette = config.colors && config.colors.length ? config.colors : DEFAULT_COLORS;
+    if (config.type !== "line") {
+        return Array.from({ length: dataLength }, (_, index) => palette[index % palette.length]);
+    }
+    return palette[0];
+}
+
+async function fetchData(endpoint) {
+    try {
+        const response = await fetch(`${API_BASE}${endpoint}`);
+        if (!response.ok) {
+            throw new Error(`Error ${response.status}`);
+        }
+        return await response.json();
+    } catch (error) {
+        console.error(`No fue posible obtener los datos desde ${endpoint}`, error);
+        return { error: true };
+    }
+}
+
+function showMessage(elementId, text) {
+    const message = document.querySelector(`.chart-empty[data-chart="${elementId}"]`);
+    if (message) {
+        if (text) {
+            message.textContent = text;
+        }
+        message.hidden = false;
+    }
+}
+
+function hideMessage(elementId) {
+    const message = document.querySelector(`.chart-empty[data-chart="${elementId}"]`);
+    if (message) {
+        message.hidden = true;
+    }
+}
+
+function renderChart(config, data) {
+    if (!Array.isArray(data) || data.length === 0) {
+        showMessage(config.elementId);
+        return;
+    }
+
+    const canvas = document.getElementById(config.elementId);
+    if (!canvas) {
+        return;
+    }
+
+    hideMessage(config.elementId);
+
+    const labels = data.map(item => item[config.labelKey]);
+    const values = data.map(item => Number(item[config.valueKey] ?? 0));
+
+    const existingChart = Chart.getChart(canvas);
+    if (existingChart) {
+        existingChart.destroy();
+    }
+
+    const datasetConfig = {
+        label: config.datasetLabel,
+        data: values,
+        backgroundColor: resolveColors(config, values.length),
+        borderColor: resolveColors(config, values.length),
+        borderWidth: config.type === "line" ? 2 : 1,
+        tension: config.type === "line" ? 0.3 : undefined,
+        fill: config.type === "line"
+    };
+
+    new Chart(canvas, {
+        type: config.type,
+        data: {
+            labels,
+            datasets: [datasetConfig]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            ...config.options
+        }
+    });
+}
+
+async function inicializarDashboard() {
+    const requests = chartConfigurations.map(config => ({ config, promise: fetchData(config.endpoint) }));
+
+    for (const { config, promise } of requests) {
+        const data = await promise;
+        if (data && data.error) {
+            showMessage(config.elementId, "No fue posible cargar la información. Intenta nuevamente más tarde.");
+            continue;
+        }
+        renderChart(config, data);
+    }
+}
+
+document.addEventListener("DOMContentLoaded", inicializarDashboard);

--- a/Hospital_Code/src/main/resources/static/estilos/estilo.css
+++ b/Hospital_Code/src/main/resources/static/estilos/estilo.css
@@ -675,3 +675,58 @@ td a:hover {
     border-color: #ff7675;
     color: #d63031;
 }
+
+.dashboard-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 2rem;
+    margin-bottom: 2rem;
+}
+
+.dashboard-card {
+    background: var(--white);
+    border-radius: 20px;
+    padding: 1.5rem;
+    box-shadow: var(--shadow);
+    border: 1px solid rgba(0, 184, 148, 0.1);
+    display: flex;
+    flex-direction: column;
+    min-height: 320px;
+}
+
+.dashboard-card--wide {
+    grid-column: span 2;
+}
+
+@media (max-width: 768px) {
+    .dashboard-card--wide {
+        grid-column: span 1;
+    }
+}
+
+.dashboard-card__header {
+    margin-bottom: 1rem;
+}
+
+.dashboard-card__header h2 {
+    margin: 0;
+    color: var(--primary-color);
+}
+
+.dashboard-card__header p {
+    margin: 0.25rem 0 0;
+    color: var(--text-light);
+    font-size: 0.95rem;
+}
+
+.dashboard-card canvas {
+    width: 100% !important;
+    flex-grow: 1;
+}
+
+.chart-empty {
+    margin-top: 1rem;
+    text-align: center;
+    color: var(--text-light);
+    font-weight: 600;
+}

--- a/Hospital_Code/src/main/resources/static/html/Catalogo/catalogo.html
+++ b/Hospital_Code/src/main/resources/static/html/Catalogo/catalogo.html
@@ -25,6 +25,7 @@
                     <li><a href="../GestionServicios/gestionservicios.html">Servicios</a></li>
                     <li><a href="../GestionIngresos/gestioningresos.html">Ingresos</a></li>
                     <li><a href="../Reportes/reportes.html">Reportes</a></li>
+                    <li><a href="../Datos/datos.html">Datos</a></li>
                     <li><a href="../Catalogo/catalogo.html">Catálogo</a></li>
                     <li><a href="../QuienesSomos.html">Quienes somos</a></li>
                 </ul>

--- a/Hospital_Code/src/main/resources/static/html/Datos/datos.html
+++ b/Hospital_Code/src/main/resources/static/html/Datos/datos.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <title>Hospital - Datos</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="../../estilos/estilo.css">
+    <link rel="shortcut icon" href="../../Media/imagen_hospital-sin-fondo.ico" type="image/x-icon">
+</head>
+<body>
+    <header class="header">
+        <div class="header-container">
+            <img src="../../Media/imagen_hospital-sin-fondo.ico" alt="Logo del hospital" class="logo" />
+        </div>
+    </header>
+
+    <div class="sidebar">
+        <nav>
+            <ul class="nav-list">
+                <li><a class="salir">Salir</a></li>
+                <li><a href="../index.html">Inicio</a></li>
+                <li><a href="../GestionPersonas/gestionpersona.html">Personas</a></li>
+                <li><a href="../GestionHabitaciones/gestionhabitaciones.html">Habitaciones</a></li>
+                <li><a href="../GestionCitas/gestioncitas.html">Citas</a></li>
+                <li><a href="../GestionArticulos/gestionarticulos.html">Artículos</a></li>
+                <li><a href="../GestionServicios/gestionservicios.html">Servicios</a></li>
+                <li><a href="../GestionIngresos/gestioningresos.html">Ingresos</a></li>
+                <li><a href="../Reportes/reportes.html">Reportes</a></li>
+                <li><a class="active" href="../Datos/datos.html">Datos</a></li>
+                <li><a href="../Catalogo/catalogo.html">Catálogo</a></li>
+                <li><a href="../QuienesSomos.html">Quienes somos</a></li>
+            </ul>
+        </nav>
+    </div>
+
+    <main class="main-content">
+        <section class="welcome-section">
+            <div class="welcome-container">
+                <div class="welcome-text">
+                    <h1>Analítica de Datos</h1>
+                    <p>Visualiza indicadores clave construidos a partir de la información registrada en el sistema.</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="dashboard-grid">
+            <article class="dashboard-card">
+                <header class="dashboard-card__header">
+                    <h2>Distribución de Personas</h2>
+                    <p>Comparativo entre pacientes y personal médico activo.</p>
+                </header>
+                <canvas id="personasTipoChart" aria-label="Gráfico de distribución de personas" role="img"></canvas>
+                <p class="chart-empty" data-chart="personasTipoChart" hidden>No se encontraron personas activas registradas.</p>
+            </article>
+
+            <article class="dashboard-card">
+                <header class="dashboard-card__header">
+                    <h2>Estado de Hospitalización</h2>
+                    <p>Resumen de ingresos hospitalizados frente a atenciones ambulatorias.</p>
+                </header>
+                <canvas id="ingresosEstadoChart" aria-label="Gráfico de ingresos por estado" role="img"></canvas>
+                <p class="chart-empty" data-chart="ingresosEstadoChart" hidden>No hay ingresos registrados en el sistema.</p>
+            </article>
+
+            <article class="dashboard-card dashboard-card--wide">
+                <header class="dashboard-card__header">
+                    <h2>Citas mensuales</h2>
+                    <p>Evolución de las citas agendadas en el tiempo.</p>
+                </header>
+                <canvas id="citasMensualesChart" aria-label="Serie temporal de citas" role="img"></canvas>
+                <p class="chart-empty" data-chart="citasMensualesChart" hidden>No existen citas registradas para mostrar.</p>
+            </article>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <hr>
+        <p>© Todos los derechos reservados 2025</p>
+        <hr>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="../../Scripts/Datos/datos.js"></script>
+    <script>
+        document.querySelector(".salir").addEventListener("click", () => {
+            if (confirm("¿Seguro que deseas cerrar sesión?")) {
+                window.location.href = "../InicioSesion/inicioSesion.html";
+            }
+        });
+    </script>
+</body>
+</html>

--- a/Hospital_Code/src/main/resources/static/html/GestionIngresos/gestioningresos.html
+++ b/Hospital_Code/src/main/resources/static/html/GestionIngresos/gestioningresos.html
@@ -26,6 +26,7 @@
                     <li><a href="../GestionServicios/gestionservicios.html">Servicios</a></li>
                     <li><a href="../GestionIngresos/gestioningresos.html">Ingresos</a></li>
                     <li><a href="../Reportes/reportes.html">Reportes</a></li>
+                    <li><a href="../Datos/datos.html">Datos</a></li>
                     <li><a href="../Catalogo/catalogo.html">Catálogo</a></li>
                     <li><a href="../QuienesSomos.html">Quienes somos</a></li>
                 </ul>

--- a/Hospital_Code/src/main/resources/static/html/QuienesSomos.html
+++ b/Hospital_Code/src/main/resources/static/html/QuienesSomos.html
@@ -25,6 +25,7 @@
             <li><a href="GestionServicios/gestionservicios.html">Servicios</a></li>
             <li><a href="GestionIngresos/gestioningresos.html">Ingresos</a></li>
             <li><a href="Reportes/reportes.html">Reportes</a></li>
+            <li><a href="Datos/datos.html">Datos</a></li>
             <li><a href="Catalogo/catalogo.html">Catálogo</a></li>
             <li><a href="QuienesSomos.html">Quienes somos</a></li>
         </ul>

--- a/Hospital_Code/src/main/resources/static/html/Reportes/reportes.html
+++ b/Hospital_Code/src/main/resources/static/html/Reportes/reportes.html
@@ -34,6 +34,7 @@
             <li><a href="../GestionServicios/gestionservicios.html">Servicios</a></li>
             <li><a href="../GestionIngresos/gestioningresos.html">Ingresos</a></li>
             <li><a href="../Reportes/reportes.html">Reportes</a></li>
+            <li><a href="../Datos/datos.html">Datos</a></li>
             <li><a href="../Catalogo/catalogo.html">Catálogo</a></li>
             <li><a href="../QuienesSomos.html">Quienes somos</a></li>
         </ul>

--- a/Hospital_Code/src/main/resources/static/html/index.html
+++ b/Hospital_Code/src/main/resources/static/html/index.html
@@ -27,6 +27,7 @@
             <li><a href="GestionServicios/gestionservicios.html">Servicios</a></li>
             <li><a href="GestionIngresos/gestioningresos.html">Ingresos</a></li>
             <li><a href="Reportes/reportes.html">Reportes</a></li>
+            <li><a href="Datos/datos.html">Datos</a></li>
             <li><a href="Catalogo/catalogo.html">Catálogo</a></li>
             <li><a href="QuienesSomos.html">Quienes somos</a></li>
         </ul>


### PR DESCRIPTION
## Summary
- add analytics DTOs, service layer, and controller endpoints that expose aggregated persona, ingreso, and cita metrics
- create the Datos dashboard page powered by Chart.js to visualize key hospital indicators
- update navigation and styling so the new analytics section is discoverable and matches the existing look and feel

## Testing
- mvn -q -DskipTests package *(fails: unable to download parent POM from Maven Central due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68dca65673e48333b494d48bc27a68bb